### PR TITLE
add online ADS and new features of ADS + fix type hinting of integrator

### DIFF
--- a/daceypy/_ADS.py
+++ b/daceypy/_ADS.py
@@ -237,14 +237,13 @@ class ADS(metaclass=PrettyType):
             The resulting domain center 
         """
         var = DA.getMaxVariables()
-        size = len(self.nsplit)
         # auxiliary variable for the initial center and width
         c = np.zeros(var)
         w = 2.0 * np.ones(var)
-        for i in range(size):
-            n = abs(self.nsplit[i]) - 1
-            w[n] = 0.5*w[n] #  before it was been evaluete the half of displacement
-            c[n] += 0.5*np.sign(self.nsplit[i])*abs(w[n]) # then the previous computation is added to the constant part
+        for split in self.nsplit:
+            n = abs(split) - 1
+            w[n] = 0.5 * w[n]  # eval half displacement
+            c[n] += 0.5 * np.sign(split) * abs(w[n]) # add it to the constant part
 
         return c
 
@@ -273,16 +272,16 @@ class ADS(metaclass=PrettyType):
         """
 
         var = DA.getMaxVariables()
-        if var!=pt.size:
+        if var != pt.size:
             raise ValueError(
-                "The dimension of selected point is wrong")
+                "The dimension of the selected point is wrong")
         else:
             c = self.center()
             w = self.width()
             if any(abs(pt-c)>0.5*w):
                 return False
             else:
-                return True                                                                        
+                return True
 
     @staticmethod
     def eval(
@@ -365,24 +364,12 @@ class ADS(metaclass=PrettyType):
         Replicate a sequence of splits on a given daceypy.array.
 
         Returns:
-            The resulting manifold after composing the splits. 
+            The resulting manifold after composing the splits.
         """
-        x = array.identity
-        size = len(nsplit)
-        for i in range(size):
-            n = abs(nsplit[i]) - 1
-            x[n] = 0.5*np.sign(nsplit[i]) + 0.5*DA(n+1)
+        x = array.identity()
+        for split in nsplit:
+            n = abs(split) - 1
+            x[n] = 0.5 * np.sign(split) + 0.5 * DA(n + 1)
             obj = obj.eval(x)
-            x[n] = DA(n+1)
+            x[n] = DA(n + 1)
         return obj
-
- 
-
-
-
-
-
-
-
-
-

--- a/daceypy/_ADS.py
+++ b/daceypy/_ADS.py
@@ -333,9 +333,9 @@ class ADS(metaclass=PrettyType):
             log_fun("Done." )
 
             # check if the domain can still be split
-            if p_el.checkSplit(toll, type_):
+            if p_el.canSplit(N_max):
                 # checks if domain needs to be split
-                if p_el.canSplit(N_max):
+                if p_el.checkSplit(toll, type_):
                     # compute splitting direction
                     dir = p_el.direction(type_)
                     # split the domain along the direction
@@ -344,14 +344,14 @@ class ADS(metaclass=PrettyType):
                     domains.extend(new_domains)
                     log_fun("A split occurred, total number of domains that need propagation are now:", len(domains))
                 else:
-                    # maximum number of splits for this domain has been reached,
-                    # just mark it as final and signal possible inaccuracies
-                    log_fun("A domain needed to split, but the maximum number of splits has been reached: possible inaccuracies may arise!")
+                    # no further splitting needed
                     final_domains.append(p_el)
+                    log_fun("One domain reached end of transformation. Still to process:", len(domains), "domains.")
             else:
-                # no further splitting needed
+                # maximum number of splits for this domain has been reached,
+                # just mark it as final and signal possible inaccuracies
+                log_fun("A domain needed to split, but the maximum number of splits has been reached: possible inaccuracies may arise!")
                 final_domains.append(p_el)
-                log_fun("One domain reached end of transformation. Still to process:", len(domains), "domains.")
 
             log_fun("Remaining domains to be transformed:", len(domains))
 

--- a/daceypy/_ADSintegrator.py
+++ b/daceypy/_ADSintegrator.py
@@ -204,25 +204,25 @@ class ADSintegrator(integrator, metaclass=PrettyType):
                          self._stack.ADSPatch.nsplit, 
                          self._runningX)
                 
-                if temp_f.checkSplit(self._errtol):
-                    # if the domain can be split
-                    if temp_f.canSplit(self._nSplitMax): 
-                        # If step is accepted and needs to be checked 
-                        # but a violation is detected simply roll back 
-                        # to previous time step
-                        # If step is not accepted will not be checked
-                        # and hence execution will never arrive here
+                # if the domain can be split
+                if temp_f.canSplit(self._nSplitMax): 
+                    # If step is accepted and needs to be checked 
+                    # but a violation is detected simply roll back 
+                    # to previous time step
+                    # If step is not accepted will not be checked
+                    # and hence execution will never arrive here
+                    if temp_f.checkSplit(self._errtol):
                         self._runningX = self._backX
                         self._input.t = self._backTime
                         self._input.h = self._backH
                     else:
-                        # the domain cannot be further split. 
-                        # Set time of violation and violation flag 
-                        # so that check can be avoided until tf 
-                        self._stack.checkBreached = True
-                        self._stack._breachTime = self._input.t
                         self._checkStep = False
                 else:
+                    # the domain cannot be further split. 
+                    # Set time of violation and violation flag 
+                    # so that check can be avoided until tf 
+                    self._stack.checkBreached = True
+                    self._stack._breachTime = self._input.t
                     self._checkStep = False
 
         return self._checkStep

--- a/daceypy/_ADSintegrator.py
+++ b/daceypy/_ADSintegrator.py
@@ -1,0 +1,405 @@
+"""
+# Differential Algebra Core Engine in Python - DACEyPy
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from __future__ import annotations
+
+from typing import (Tuple, Union, Optional, List, Type)
+
+import numpy as np
+from numpy.typing import NDArray
+
+import daceypy
+
+from .RK import RKCoeff, RK78
+
+from ._integrator import integrator
+
+from ._PrettyType import PrettyType
+
+from ._ADS import ADS
+
+
+class ADSstate(metaclass=PrettyType):
+    """
+    online ADS (Adaptive Domain Splitting) base element.
+    """
+    def __init__(
+        self, 
+        ADSPatch: ADS = None, 
+        time: float = 0.0, 
+        stepsize : float = 0.0, 
+        checkBreached: Optional[bool] = False, 
+        splitTimes: Optional[List[float]] = [],
+        ):
+        """
+        Initialize an instance of ADSstate class for propagation.
+
+        Args:
+            ADSParch:
+              instance of the class ADS that stores the current patch
+              under analysis
+            time: reference epoch for the patch
+            stepsize: stepsize of the integrator at the patch epoch
+            checkBreached: 
+              check if patch needed split even though it was impossible
+              during its propagation
+            splitTimes: list of split times for the current patch
+
+        See also:
+            ADS
+        """
+        # ADSstate if a support class, its instances are used to store 
+        # ADS info during propagation.
+
+        self.ADSPatch : ADS = ADSPatch
+        "The current ADS patch"
+        self.time: float = time
+        "Time at witch current patch started existing"
+        self.stepsize: float = stepsize
+        "Stepsize of the integrator when this patch was created"
+        
+        # moreover it has additional support variables to store ADS 
+        # info in a easily accessible way.
+
+        self.splitTimes: list[float] = splitTimes
+        "List of split times for each patch"
+        self.checkBreached: bool = checkBreached
+        "Check if domain can be further split"
+        # defined as "protected" because it should only be modified by 
+        # a couple of class methods 
+        self._breachTime: float = -1.0
+        "Time at which split became necessary even though impossible"
+
+
+class ADSintegrator(integrator, metaclass=PrettyType):
+    """
+    ADS integrator to perform splits online during propagation.
+    """
+    def __init__(self, RKcoeff: Optional[RKCoeff]=RK78()) -> None:
+        """
+        Initialize an instance of the custom propagator capable of 
+        dealing with online ADS.
+
+        Args:
+            RKcoeff:
+              instance of the class RKCoeff that stores the coefficients
+              of the Numerical Propagation Scheme
+
+        See also:
+            integrator
+            RK.RKCoeff
+        """
+
+        # call to parent class constructor:
+        # ADS is only available for daceypy.array type
+        super(ADSintegrator, self).__init__(RKcoeff, daceypy.array)
+        
+        self._nSplitMax: int = 0      
+        "Maximum number of split for the ADS routine"
+
+              
+        self._errtol: Union[float, NDArray[np.double]] = None
+        "maximum truncation tolerance to determine split condition"
+        
+        self._stack: ADSstate = None 
+        "ADS patch at the top of the stack with enhanced info"
+        
+        return
+
+    def _InitializeList(
+        self, 
+        set: List[ADS], 
+        splitTimesList: Optional(List[List[float]]) = [],
+        ) -> List[ADSstate]:
+        """
+        Initializes the list of ADS objects that need propagation as
+        instances of ADSstate required by this custom propagator.
+
+        Args:
+            set: initial list of ADS objects.
+            splitTimesList:
+              optional list of split times of each element of set. 
+              This is only required if one wants to propagate a domain
+              that was already split while preserving its history.
+
+        Returns:
+            List of ADSstate instances ready for online ADS propagation
+
+        Raises:
+            ValueError
+        """
+
+        # NB: needs to be called after integrator.loadTime and 
+        # integrator.loadStepSize
+ 
+        out : List[ADSstate] = []
+
+        # this part is only necessary if a pre-split domain is provided
+        # and one wants to retain the split history (times).
+        # If a list of split times is provided it must have proper size.
+        # If it is not provided the info will be lost and only the new 
+        # splits will be saved at the end of the propagation.
+        if not splitTimesList:
+            splitTimesList = [[]]*len(set)
+        elif len(splitTimesList) != len(set):
+            raise ValueError(
+                "specified splitTimesList must have the same length"
+                "as the number of elements in the initial set.")
+        else:
+            for i in range(len(set)):
+                if len(set[i].nsplit) != len(splitTimesList[i]):
+                    raise ValueError(
+                        f"specified splitTimesList[{i}] must have the "
+                        "same length as the number of splits in the "
+                        "corresponding set element.")
+    
+        # create a list of ADSstate instances from the initial domains
+        for i in range(len(set)):
+            temp = ADSstate(
+                   set[i], 
+                   self._t0, 
+                   self._input.h, 
+                   splitTimes = splitTimesList[i])
+            
+            out.append(temp)
+        # element at the top of the stack is stored in a variable
+        self._stack=temp
+    
+        return out
+    
+    def _CallBack_CheckEvent(self) -> bool:
+        """
+        Check if integration should stop according to an event function
+        (default is False). This version overloads that of integrator.
+
+        Returns:
+            True if the integration needs to be stopped
+
+        See also:
+            integrator._CallBack_CheckEvent
+        """
+        # function that overloads integrator.CallBack_CheckEvent:
+        # If the current domain has already been tested and seen that 
+        # cannot be split simply go ahead without doing anything
+        if self._stack.checkBreached:
+            self._checkStep = False
+        else:
+            if (self._checkStep):
+                # if the integration step was accepted check for split
+                temp_f = ADS(
+                         self._stack.ADSPatch.box, 
+                         self._stack.ADSPatch.nsplit, 
+                         self._runningX)
+                
+                if temp_f.checkSplit(self._errtol):
+                    # if the domain can be split
+                    if temp_f.canSplit(self._nSplitMax): 
+                        # If step is accepted and needs to be checked 
+                        # but a violation is detected simply roll back 
+                        # to previous time step
+                        # If step is not accepted will not be checked
+                        # and hence execution will never arrive here
+                        self._runningX = self._backX
+                        self._input.t = self._backTime
+                        self._input.h = self._backH
+                    else:
+                        # the domain cannot be further split. 
+                        # Set time of violation and violation flag 
+                        # so that check can be avoided until tf 
+                        self._stack.checkBreached = True
+                        self._stack._breachTime = self._input.t
+                        self._checkStep = False
+                else:
+                    self._checkStep = False
+
+        return self._checkStep
+    
+    def _SplitStateProcess(
+        self, 
+        xf: daceypy.array, 
+        listIn: List[ADSstate], 
+        listOut: List[ADSstate],
+        ) -> Tuple[List[ADSstate], List[ADSstate]]:
+        """
+        Updates the list of ADS objects that need propagation online.
+
+        Args:
+            xf: current state of the propagation.
+            listIn: list of ADSstates that still need to be propagated.
+            listOut: list of ADSstates that reached tf.
+
+        Returns:
+            List of ADSstate instances that still need propagation
+            List of ADSstate instances that reached tf
+            
+        See also:
+            ADS
+        """
+        # create temporary ads patch with latest propagator state
+        state = ADS(
+                self._stack.ADSPatch.box, 
+                self._stack.ADSPatch.nsplit, 
+                xf)
+
+        # if not at end of propagation this means that a split was 
+        # necessary (and possible) from how we defined the checkevent
+        if (not self._reachstime):
+
+            print(
+                "The domain was split at instant ",
+                self._input.t,
+                " and continued the propagation...")
+            
+            # compute split subdomains
+            dir=state.direction()
+            Dl, Dr = state.split(dir)
+            
+            # update list of split times for each subdomain
+            tempSplitTimes = self._stack.splitTimes.copy()
+            tempSplitTimes.append(self._input.t)
+
+            # add elements to the list of objects that need propagation
+            tempL = ADSstate(
+                    Dl, 
+                    self._input.t, 
+                    self._input.h, 
+                    splitTimes = tempSplitTimes)
+            tempR = ADSstate(
+                    Dr, 
+                    self._input.t, 
+                    self._input.h, 
+                    splitTimes = tempSplitTimes)
+            
+            # add one of the domains at the top of the stack
+            self._stack = tempR
+            # add other domain to list of element that need propagation
+            listIn.append(tempL)
+        else:
+            # only here if reached tf (regardless of accuracy breach)
+            tempD = ADSstate(
+                    state, 
+                    self._input.t, 
+                    self._input.h, 
+                    self._stack.checkBreached, 
+                    splitTimes = self._stack.splitTimes)
+            
+            tempD._breachTime = self._stack._breachTime
+            
+            # add domain to final list: this step could be moved
+            # outside of this function to avoid continuously passing 
+            # listOut in and out of this function. It is only kept here
+            # to simplify the propagate function but this could be
+            # changed in the future for efficiency by simply passing
+            # tempD as output.
+
+            listOut.append(tempD)
+
+        return listIn, listOut
+
+    def _importfromList(self, ListIn: List[ADSstate]) -> None:
+        """
+        Remove from the list of ADS elements that need propagation the 
+        one at the top of the stack and prepare it for propagation.
+
+        Args:
+            listIn: list of ADSstates that still need to be propagated.
+            
+        See also:
+            integrator
+        """
+        # put first element to top of the stack
+        self._stack = ListIn.pop()
+        # pass its time and stepsize to the propagator
+        self._input.t = self._stack.time
+        self._input.h = self._stack.stepsize
+        # set condition that it has not reached final time
+        self._ReachsFinalTime() 
+        return None
+    
+    def loadADSopt(
+        self, 
+        tol: Union[float, NDArray[np.double]] = 1e-4, 
+        nsplit: int = 15,
+        ) -> None:
+        """
+        Load ADS options.
+
+        Args:
+            tol: maximum truncation error tolerance.
+            nsplit: maximum number of splits per each domain.
+        """
+
+        self._errtol = tol
+        self._nSplitMax = nsplit
+        
+        return
+
+    def propagate(
+        self, 
+        set: List[ADS], 
+        t1: float, 
+        t2: float,
+        splitTimesList: Optional(List[List[float]]) = [],
+        ) -> List[ADSstate]:
+        """
+        Propagates the initial list of ADS objects while dealing with 
+        online ADS. Overloads parent class method integrator.propagate.
+
+        Args:
+            List: list of ADS elements that need propagation.
+            t1: initial reference time for each element of the List.
+            t2: final time of the propagation.
+            splitTimesList:
+              optional list of split times of each element of set. 
+              This is only required if one wants to propagate a domain
+              that was already split while preserving its history.
+
+        Returns:
+            List of ADSstate instances that reached tf
+            
+        See also:
+            integrator.propagate
+        """
+
+        """ 
+        NB: t1 and t2 are not used in this function. They are only left
+        here to maintain same syntax as the parent class method that 
+        this function overloads. The initial time of the propagation 
+        MUST be set through integrator.loadTime and it will be adapted
+        online by each patch. Conversely, tf is fixed and it MUST be
+        set through integrator.loadTime.
+        """
+        
+        # list of final domains
+        listOut : List[ADSstate] = [] 
+        # create initial list from initial set of domains
+        listIn = self._InitializeList(set, splitTimesList)
+
+        print("Let's start propagation...")
+        # loop until list of domains is not empty
+        while listIn:
+            # remove first domain and put it at the top of the stack
+            self._importfromList(listIn)
+            # loop until final time is reached for the domain
+            while (not self._reachstime):
+                xf = super(ADSintegrator, self).propagate(self._stack.ADSPatch.manifold, self._input.t, t2)
+                # after each call to propagation update list of patches
+                listIn, listOut = self._SplitStateProcess(xf, listIn, listOut)
+
+        print("Propagation completed. ")
+
+        return listOut
+

--- a/daceypy/__init__.py
+++ b/daceypy/__init__.py
@@ -37,6 +37,7 @@ __all__ = (
     "ADS",
     "RK",
     "integrator",
+    "ADSintegrator",
 )
 
 from ._version import __version__
@@ -49,6 +50,7 @@ from . import op
 from ._ADS import ADS
 from . import RK
 from ._integrator import integrator
+from ._ADSintegrator import ADSintegrator
 
 init = DA.init
 isInitialized = DA.isInitialized

--- a/daceypy/_integrator.py
+++ b/daceypy/_integrator.py
@@ -486,8 +486,8 @@ def PicardLindelof(
     x: Union[daceypy.array, NDArray[np.double]],
     direction: int, 
     tf: float,
-    f: Callable[[daceypy.array], Union[daceypy.DA, float]],
-    ) -> daceypy.array:
+    f: Callable[[daceypy.array, Union[daceypy.DA, float]], daceypy.array],
+) -> daceypy.array:
     """
     Computes the time expansion at final time with Picard Lindelof operator
 

--- a/daceypy/_integrator.py
+++ b/daceypy/_integrator.py
@@ -157,7 +157,7 @@ class integrator(metaclass=PrettyType):
     @staticmethod
     def f(
         x: Union[daceypy.array, NDArray[np.double]],
-        t: Union[daceypy.DA, float],
+        t: float,
     ) -> Union[daceypy.array, NDArray[np.double]]:
         """
         Computes the righ-hand-side of the ODE.
@@ -165,7 +165,7 @@ class integrator(metaclass=PrettyType):
 
         Args:
             x: state (either numpy.ndarray or daceypy.array)
-            t: time (either float or daceypy.DA)
+            t: time (float)
 
         Returns:
             The time derivatives of the state x at time t
@@ -276,7 +276,11 @@ class integrator(metaclass=PrettyType):
         Adapt the stepsize according to step error.
         """
 
-        self._input.h *= min(4.0, max(0.1, 0.9 * pow(1.0 / self._err, 1.0 / (self._RKcoeff.RK_order + 1.0))))
+        if self._err == 0.0:
+            self._input.h=4.0
+        else:
+            self._input.h *= min(4.0, max(0.1, 0.9 * pow(1.0 / self._err, 1.0 / (self._RKcoeff.RK_order + 1.0))))
+        
 
         if abs(self._input.h) <= self._input.minh * 1.2:
             self._input.h /= 3.0
@@ -301,9 +305,15 @@ class integrator(metaclass=PrettyType):
             t2: final time (either daceypy.DA or float)
         """
         if not isinstance(t1, float):
-            raise TypeError(f"t1 must be a float (\"{type(t1)}\") was given")
+            if isinstance(t1, int):
+                t1=float(t1)
+            else:
+                raise TypeError(f"t1 must be a float (\"{type(t1)}\") was given")
         if not isinstance(t2, float):
-            raise TypeError(f"t2 must be a float (\"{type(t2)}\") was given")
+            if isinstance(t2,int):
+                t2=float(t2)
+            else:
+                raise TypeError(f"t2 must be a float (\"{type(t2)}\") was given")
 
         self._t0 = t1
         self._tf = t2
@@ -347,7 +357,7 @@ class integrator(metaclass=PrettyType):
         if self._input.minh == 0.0:
             self._input.minh = self._input.maxh * 2.2e-16
 
-    def propagate(self, Initset: Union[daceypy.array, NDArray[np.double]], t1: Union[daceypy.DA, float], t2: Union[daceypy.DA, float]) -> Union[daceypy.array, NDArray[np.double]]:
+    def propagate(self, Initset: Union[daceypy.array, NDArray[np.double]], t1: float, t2: float) -> Union[daceypy.array, NDArray[np.double]]:
         """
         Propagates state in time interval according to selected numerical scheme.
 
@@ -474,9 +484,10 @@ def _getepstolDA(self, pn: daceypy.array) -> NDArray[np.double]:
 
 def PicardLindelof(
     x: Union[daceypy.array, NDArray[np.double]],
-    direction: int, tf: float,
+    direction: int, 
+    tf: float,
     f: Callable[[daceypy.array], Union[daceypy.DA, float]],
-) -> daceypy.array:
+    ) -> daceypy.array:
     """
     Computes the time expansion at final time with Picard Lindelof operator
 

--- a/docs/ADS/1Basics-Ex.py
+++ b/docs/ADS/1Basics-Ex.py
@@ -118,7 +118,7 @@ def main() -> None:
 
     plt.show()
 
-    print('end')
+    print('End')
 
 
 if __name__ == "__main__":

--- a/docs/Tutorials/Tutorial1/Example11timeDAintegrator.py
+++ b/docs/Tutorials/Tutorial1/Example11timeDAintegrator.py
@@ -182,6 +182,7 @@ def RK78(Y0: array, X0: float, X1: float, f: Callable[[array, float], array]):
 
     return Y1
 
+
 def TBP(x: array, t: float) -> array:
     pos: array = x[:3]
     vel: array = x[3:]
@@ -189,6 +190,7 @@ def TBP(x: array, t: float) -> array:
     acc: array = -mu * pos / (r ** 3)
     dx = vel.concat(acc)
     return dx
+
 
 def TBP_time(x: array, tau: float, t0: DA, tf: DA) -> array:
     # input time tau is normalized. To retrieve t: tau*(tf-t0)
@@ -203,6 +205,7 @@ def TBP_time(x: array, tau: float, t0: DA, tf: DA) -> array:
     dx = (tf-t0)*(vel.concat(acc))
     return dx
 
+
 class TBP_integrator_time(integrator):
     def __init__(self, RK: RK.RKCoeff = RK.RK78(), stateType: Type = np.ndarray):
         super(TBP_integrator_time, self).__init__(RK, stateType)
@@ -215,12 +218,14 @@ class TBP_integrator_time(integrator):
     def f(self, x, t):
         return TBP_time(x,t, self.T0, self.TF)
 
+
 class TBP_integrator_float(integrator):
     def __init__(self, RK: RK.RKCoeff = RK.RK78(), stateType: Type = np.ndarray):
         super(TBP_integrator_float, self).__init__(RK, stateType)
 
     def f(self, x, t):
         return TBP(x,t)
+
 
 def main():
 
@@ -252,7 +257,7 @@ def main():
 
     # Alternatively, one can use the modular propagator provided in daceypy:
     # creation of instance of propagator class with correct dynamics
-    propagator_78=TBP_integrator_time(RK.RK78(), array)
+    propagator_78 = TBP_integrator_time(RK.RK78(), array)
 
     # custom properties to store initial and final time as DA variables:
     # they will be used for scaling the dynamics as previously done with
@@ -271,7 +276,7 @@ def main():
     propagator_78f.loadTime(0.0,  np.pi * np.sqrt(a**3 / mu))
     propagator_78f.loadTol(20*1e-12, 1e-12)
     propagator_78f.loadStepSize()
-    xf_modular_float=propagator_78f.propagate(x0, 0.0, np.pi * np.sqrt(a**3 / mu))
+    xf_modular_float = propagator_78f.propagate(x0, 0.0, np.pi * np.sqrt(a**3 / mu))
 
     print("Final error of constant part with and without time scaling: \n",
            xf_modular.cons()-xf_modular_float)
@@ -279,7 +284,7 @@ def main():
     # Comparison with expansion at final time computed with picard lindelof operator:
     # NB: only possible at final time
 
-    xf_PL=PicardLindelof(array(xf_modular_float), 7, np.pi * np.sqrt(a**3 / mu), TBP)
+    xf_PL = PicardLindelof(array(xf_modular_float), 7, np.pi * np.sqrt(a**3 / mu), TBP)
 
     print("Error of final time expansion (integrator vs Picard-Lindelof): \n",
            xf_modular - xf_PL)


### PR DESCRIPTION
Online ADS during propagation has been added leveraging base submodules _integrator and _ADS.
In particular the following changes have been implemented:

1. Added four new methods for the class ADS: compute the size and center of a given domain, determine if a point lies inside a domain, replay a history of splitting along given directions.
2. Added the new submodule _ADSintegrator which implements a subclass of _integrator that deals with splitting during the propagation with variable stepsize.
3. Fixed type hinting for time variables in the integrator (only available for float, therer is a tutorial that explains how to deal with DA time).
4. Fixed a couple bugs in integrator: deal with integer input time, avoid crash while adapting the final stepsize to avoid an inf (even though it was not used).
5. Removed annoying prints from ADS tutorials.
6. Created a tutorial for online ADS.