### PR TITLE
Fix bug in auxiliary function _eliminate causing DA matrix inversion errors

### DIFF
--- a/daceypy/_array.py
+++ b/daceypy/_array.py
@@ -1161,7 +1161,7 @@ def _eliminate(k: int, A: array, R: List[int]):
         if j != k:
             A[R[k], j] /= A[R[k], k]
 
-    A[R[k], k] **= -1
+    A[R[k], k] = 1 / A[R[k], k]
 
     for i in range(n):
         if i != k:


### PR DESCRIPTION
This PR fixes a bug in the auxiliary function _eliminate that led to incorrect DA matrix inversion during the execution of inv().

Wrong: A[R[k], k] **= -1

Correct: A[R[k], k] = 1 / A[R[k], k]

----------------------------------------------------------------
The following example now runs correctly and returns an identity matrix for A @ inv(A):

DA.init(5, 3)
A = array([[1.2+DA(1), 8+DA(2)], [3, 0.5+DA(3)]])
B = A.inv()
print(Check A*inv(A) = identity matrix: \n", A@B))